### PR TITLE
Implement fuzzy search in NameContainsKeywordsPredicate

### DIFF
--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -3,24 +3,72 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code Name} matches any of the keywords given
+ * using fuzzy search.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
 
+    /**
+     * Constructor for NameContainsKeywordsPredicate.
+     *
+     * @param keywords List of keywords to match against the name.
+     */
     public NameContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
+    /**
+     * Tests if the {@code Name} of a {@code Person} matches any of the keywords
+     * given using fuzzy search.
+     *
+     * @param person The {@code Person} to test against.
+     * @return true if the name of the person matches any of the keywords given
+     * using fuzzy search, false otherwise.
+     */
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+        String fullName = person.getName().fullName.toLowerCase();
+        for (String keyword : keywords) {
+            if (isFuzzyMatch(fullName, keyword.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
     }
 
+    /**
+     * Checks if a keyword matches a name using fuzzy search.
+     *
+     * @param fullName The name to match against.
+     * @param keyword The keyword to match.
+     * @return true if the keyword matches a contiguous substring of the name,
+     * false otherwise.
+     */
+    private boolean isFuzzyMatch(String fullName, String keyword) {
+        int lastMatch = -1;
+        for (int i = 0; i < keyword.length(); i++) {
+            char c = keyword.charAt(i);
+            int index = fullName.indexOf(c, lastMatch + 1);
+            if (index == -1) {
+                return false;
+            }
+            if (lastMatch != -1 && index - lastMatch > 1) {
+                return false;
+            }
+            lastMatch = index;
+        }
+        return true;
+    }
+
+    /**
+     * Checks if this object is equal to another object.
+     *
+     * @param other The object to compare to.
+     * @return true if the two objects are equal, false otherwise.
+     */
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.function.Predicate;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given
  * using fuzzy search.
  */
@@ -25,8 +24,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
      * given using fuzzy search.
      *
      * @param person The {@code Person} to test against.
-     * @return true if the name of the person matches any of the keywords given
-     * using fuzzy search, false otherwise.
+     * @return true if the name of the person matches any of the keywords given using fuzzy search, false otherwise.
      */
     @Override
     public boolean test(Person person) {
@@ -44,8 +42,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
      *
      * @param fullName The name to match against.
      * @param keyword The keyword to match.
-     * @return true if the keyword matches a contiguous substring of the name,
-     * false otherwise.
+     * @return true if the keyword matches a contiguous substring of the name,false otherwise.
      */
     private boolean isFuzzyMatch(String fullName, String keyword) {
         int lastMatch = -1;

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -34,28 +34,36 @@ public class NameContainsKeywordsPredicateTest {
         // null -> returns false
         assertFalse(firstPredicate.equals(null));
 
-        // different person -> returns false
+        // different keywords -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));
     }
 
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Ali"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Multiple keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Al", "Bo"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Only one matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
-        assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "rol"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Cerol").build()));
 
         // Mixed-case keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("lice", "BOB"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Fuzzy search
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("vid"));
+        assertTrue(predicate.test(new PersonBuilder().withName("David Li").build()));
+
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Ol", "Ro", "DRI", "IGO"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Olivia Rodrigo").build()));
     }
+
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
@@ -64,8 +72,8 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
 
         // Non-matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Cerol"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Boa").build()));
 
         // Keywords match phone, address and pay rate, but does not match name
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "Main", "Street", "10"));


### PR DESCRIPTION
Modified the `NameContainsKeywordsPredicate` class to implement a fuzzy search that matches only contiguous substrings.

The `isFuzzyMatch` method was updated to keep track of the last matched index in both `fullName` and `keyword`. If the difference between the last matched index in `fullName` and the current matched index is greater than 1, then it indicates that the matched characters are not contiguous, and the method returns false.

Example: David Li will appear in Find Dav, vid, Li, Da, av, ID etc.

The `NameContainsKeywordsPredicateTest` class was modified to include additional test cases to test the new fuzzy search implementation.

Closes #15 